### PR TITLE
fix: replace hardcoded paths with relative paths

### DIFF
--- a/BEST-PRACTICES.md
+++ b/BEST-PRACTICES.md
@@ -59,7 +59,7 @@ allowed-tools:
 
 ### 1. Verify Setup
 ```bash
-node ~/.claude/skills/<name>/scripts/setup.mjs
+node scripts/setup.mjs
 ```
 
 ### 2. Common Operations

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Replace placeholders like `{{SKILL_NAME}}`, `{{DESCRIPTION}}`, etc.
 cd my-skill-claude-skill
 git init && git add -A && git commit -m "Initial release"
 
-node scripts/create-repo.mjs \
+node skills/skill-builder/scripts/create-repo.mjs \
   --name "my-skill-claude-skill" \
   --description "Claude Code skill for my purpose" \
   --topics "claude,claude-code,claude-plugin,my-domain"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ mkdir -p my-skill-claude-skill/skills/my-skill/scripts
 ### 2. Copy Templates
 
 ```bash
-cp -r ~/.claude/skills/skill-builder/templates/* my-skill-claude-skill/
+cp -r templates/* my-skill-claude-skill/
 ```
 
 ### 3. Customize Files
@@ -56,7 +56,7 @@ Replace placeholders like `{{SKILL_NAME}}`, `{{DESCRIPTION}}`, etc.
 cd my-skill-claude-skill
 git init && git add -A && git commit -m "Initial release"
 
-node ~/.claude/skills/skill-builder/skills/skill-builder/scripts/create-repo.mjs \
+node scripts/create-repo.mjs \
   --name "my-skill-claude-skill" \
   --description "Claude Code skill for my purpose" \
   --topics "claude,claude-code,claude-plugin,my-domain"

--- a/SKILL.md
+++ b/SKILL.md
@@ -342,7 +342,7 @@ export async function updateProject(projectId: string) { ... }
 
 Run the validation script:
 ```bash
-npx tsx ~/.claude/skills/skill-builder/scripts/validate-skill.ts skill-name/
+npx tsx scripts/validate-skill.ts skill-name/
 ```
 
 ---
@@ -448,10 +448,10 @@ Run before committing skill changes:
 
 ```bash
 # Validate a skill
-npx tsx ~/.claude/skills/skill-builder/scripts/validate-skill.ts path/to/skill
+npx tsx scripts/validate-skill.ts path/to/skill
 
 # Check for project-specific content
-npx tsx ~/.claude/skills/skill-builder/scripts/check-generalization.ts path/to/skill
+npx tsx scripts/check-generalization.ts path/to/skill
 ```
 
 ---
@@ -718,7 +718,7 @@ This hook provides a reminder when editing skill files. For full validation, run
 grep -ri "skillsmith\|smi-[0-9]\|specific-uuid" ~/.claude/skills/<skill-name>/
 
 # Or use the validation script
-npx tsx ~/.claude/skills/skill-builder/scripts/check-generalization.ts ~/.claude/skills/<skill-name>/
+npx tsx scripts/check-generalization.ts ~/.claude/skills/<skill-name>/
 ```
 
 ### CLAUDE.md Integration

--- a/scripts/validate-skill.ts
+++ b/scripts/validate-skill.ts
@@ -7,7 +7,7 @@
  *
  * Usage:
  *   npx tsx validate-skill.ts <skill-path>
- *   npx tsx validate-skill.ts ~/.claude/skills/linear
+ *   npx tsx validate-skill.ts path/to/skill
  */
 
 import * as fs from 'fs'
@@ -314,7 +314,7 @@ function main() {
     console.log('Usage: validate-skill.ts <skill-path>')
     console.log('')
     console.log('Example:')
-    console.log('  npx tsx validate-skill.ts ~/.claude/skills/linear')
+    console.log('  npx tsx validate-skill.ts path/to/skill')
     process.exit(1)
   }
 

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -53,7 +53,7 @@ Guide user through customizing:
 Run the automation script:
 
 ```bash
-node scripts/create-repo.mjs \
+node skills/skill-builder/scripts/create-repo.mjs \
   --name "<skill-name>-claude-skill" \
   --description "Claude Code skill for <purpose>" \
   --topics "claude,claude-code,claude-plugin,<domain-topics>"
@@ -284,7 +284,7 @@ cp templates/* docker-claude-skill/
 # - Add docker-specific patterns to SKILL.md
 
 # 4. Publish
-node scripts/create-repo.mjs \
+node skills/skill-builder/scripts/create-repo.mjs \
   --name "docker-claude-skill" \
   --description "Claude Code skill for Docker container development" \
   --topics "claude,claude-code,claude-plugin,docker,containers,devops"

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -37,7 +37,7 @@ Copy and customize these templates:
 
 ```bash
 # Copy all templates to working directory
-cp -r ~/.claude/skills/skill-builder/templates/* /path/to/new-skill/
+cp -r templates/* /path/to/new-skill/
 ```
 
 ### 3. Customize Files
@@ -53,7 +53,7 @@ Guide user through customizing:
 Run the automation script:
 
 ```bash
-node ~/.claude/skills/skill-builder/skills/skill-builder/scripts/create-repo.mjs \
+node scripts/create-repo.mjs \
   --name "<skill-name>-claude-skill" \
   --description "Claude Code skill for <purpose>" \
   --topics "claude,claude-code,claude-plugin,<domain-topics>"
@@ -276,7 +276,7 @@ Before publishing:
 mkdir -p docker-claude-skill/skills/docker/scripts
 
 # 2. Copy templates
-cp ~/.claude/skills/skill-builder/templates/* docker-claude-skill/
+cp templates/* docker-claude-skill/
 
 # 3. Customize (example)
 # - Replace {{SKILL_NAME}} with "docker"
@@ -284,7 +284,7 @@ cp ~/.claude/skills/skill-builder/templates/* docker-claude-skill/
 # - Add docker-specific patterns to SKILL.md
 
 # 4. Publish
-node ~/.claude/skills/skill-builder/skills/skill-builder/scripts/create-repo.mjs \
+node scripts/create-repo.mjs \
   --name "docker-claude-skill" \
   --description "Claude Code skill for Docker container development" \
   --topics "claude,claude-code,claude-plugin,docker,containers,devops"

--- a/templates/README-template.md
+++ b/templates/README-template.md
@@ -25,7 +25,7 @@ git clone https://github.com/{{AUTHOR}}/{{SKILL_NAME}}-claude-skill ~/.claude/sk
 ### Verify Setup
 
 ```bash
-node ~/.claude/skills/{{SKILL_NAME}}/skills/{{SKILL_NAME}}/scripts/setup.mjs
+node scripts/setup.mjs
 ```
 
 ## How It Works

--- a/templates/SKILL-template.md
+++ b/templates/SKILL-template.md
@@ -22,7 +22,7 @@ allowed-tools:
 
 ```bash
 # Run setup check
-node ~/.claude/skills/{{SKILL_NAME}}/skills/{{SKILL_NAME}}/scripts/setup.mjs
+node scripts/setup.mjs
 ```
 
 ### 2. Common Operations


### PR DESCRIPTION
## Summary
- Replace hardcoded ~/.claude/skills/ script invocation paths with relative paths
- Supports project-local skill installations in .claude/skills/
- Install/clone destination paths preserved as-is

## Linear Issue
SMI-2426

Generated with [claude-flow](https://github.com/ruvnet/claude-flow)